### PR TITLE
g++ insists on noexecept

### DIFF
--- a/include/cppcoro/task.hpp
+++ b/include/cppcoro/task.hpp
@@ -49,7 +49,7 @@ namespace cppcoro
 				// were crashing under x86 optimised builds.
 				template<typename PROMISE>
 				CPPCORO_NOINLINE
-				void await_suspend(cppcoro::coroutine_handle<PROMISE> coroutine)
+				void await_suspend(cppcoro::coroutine_handle<PROMISE> coroutine) noexcept
 				{
 					task_promise_base& promise = coroutine.promise();
 


### PR DESCRIPTION
G++-10 insists that await_suspend be declared noxcept