### PR TITLE
+<utility> for std::exchange

### DIFF
--- a/lib/static_thread_pool.cpp
+++ b/lib/static_thread_pool.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <mutex>
 #include <chrono>
+#include <utility>
 
 namespace
 {


### PR DESCRIPTION
Add `<utility>` header for `std::exchange` used in this implementation file, otherwise the unit (and the whole lib consequently) cannot be compiled/build in some environments, e.g. ArchLinux/AUR -- all, as usual, depends on compilation order, compiler version etc.
It compiles/builds allright (by AUR) after this patch.)